### PR TITLE
add a check condition while dump buffer size may be tampered with

### DIFF
--- a/ta/platform/stub.c
+++ b/ta/platform/stub.c
@@ -207,6 +207,10 @@ int platform_dump_status(char *dump, int size)
 	int i, j, writed;
 	char *tmp = dump;
 
+	if (size < 2047) {
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
 	writed = snprintf(tmp, size, "SDP STUB platform\n");
 	tmp += writed;
 	size -= writed;


### PR DESCRIPTION
This pull request addresses a potential security issue caused by missing validation checks in the TA code. Although a 2048-byte dump buffer is defined on the REE side, the TA code should block malicious inputs, such as params[0].memref.size smaller than 2048 bytes that may cause buffer overflow.
Please kindly consider our pull request, many thanks!